### PR TITLE
CODEOWNERS를 추가해서 리뷰어를 자동 설정하기

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,14 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+*       @loopy-cho @bohyunjung @minwoo
+
+# Order is important; the last matching pattern takes the most
+# precedence. When someone opens a pull request that only
+# modifies JS files, only @js-owner and not the global
+# owner(s) will be requested for a review.
+# *.js    @js-owner


### PR DESCRIPTION
CODEOWNERS 파일에 (아직까지는 가장 활발히 작업중인) @loophy-cho @bohyunjung @minwoo을 넣었습니다.
하는일: PR이 요청되면, 자동으로 세 사람을 리뷰어 목록으로 넣어줍니다.

CODEOWNERS에 관한 자세한 설명은 아래 링크:
https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners